### PR TITLE
Fixing Authorlist name control

### DIFF
--- a/MichiganTech.cls
+++ b/MichiganTech.cls
@@ -40,7 +40,10 @@
 \RequirePackage{makeidx}
 \RequirePackage{multicol}
 \RequirePackage{multirow}
-\RequirePackage[square,comma,sort,numbers]{natbib}
+%Use format of American Physical Society(APS) Journals, with just 1 name before et al.
+\RequirePackage[style=phys, articletitle=false, biblabel=brackets,
+chaptertitle=false, pageranges=false, maxnames=1]{biblatex}
+
 \RequirePackage{nextpage}
 \RequirePackage{pstricks}
 \RequirePackage{pst-all}

--- a/References/References.tex
+++ b/References/References.tex
@@ -1,6 +1,5 @@
 \cleartooddpage[\thispagestyle{empty}]
 \phantomsection
 \interlinepenalty=1000
-\bibliographystyle{jpc}
 \nocite{*}
-\bibliography{References/References}
+\printbibliography

--- a/john_DEGREE.tex
+++ b/john_DEGREE.tex
@@ -8,6 +8,10 @@
 \documentclass[Degree=PhD]{MichiganTech}
 
 %
+%Using this as the bibliography file
+\addbibresource{References/References.bib}
+
+%
 % Document begins
 \begin{document}
 


### PR DESCRIPTION
Implemented biblatex removing natbib, allowing for author list number control. 

Template now uses APS style by default according to http://ctan.math.illinois.edu/macros/latex/contrib/biblatex-contrib/biblatex-phys/biblatex-phys.pdf
The only modification is the maximum 1 author name, which some may which to extend. 

This pull request solves issue #3 